### PR TITLE
feat: add 'FC' status to OrderStatus enum and update related components

### DIFF
--- a/prisma/migrations/20250604170825_add_fc_order_status/migration.sql
+++ b/prisma/migrations/20250604170825_add_fc_order_status/migration.sql
@@ -1,0 +1,8 @@
+-- AlterEnum
+ALTER TYPE "OrderStatus" ADD VALUE 'FICHA_CADASTRAL';
+
+-- DropForeignKey
+ALTER TABLE "Order" DROP CONSTRAINT "Order_userId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "Order" ADD CONSTRAINT "Order_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -107,6 +107,7 @@ model Order {
 
 enum OrderStatus {
   UNKNOWN     @map("DESCONHECIDO")  // Initial state
+  FC          @map("FICHA_CADASTRAL") // Etiqueta emitida
   POSTED      @map("POSTADO")       // Found in Correios
   NOT_FOUND   @map("NAO_ENCONTRADO") // Not found in Correios
   IN_TRANSIT  @map("EM_TRANSITO")   // When tracking shows movement

--- a/src/app/_components/orders/dashboard/DashboardWidgetsServer.tsx
+++ b/src/app/_components/orders/dashboard/DashboardWidgetsServer.tsx
@@ -2,6 +2,25 @@
 import { api } from "~/trpc/server";
 import { DashboardWidgetsClient } from "./DashboardWidgetsClient";
 
+// Helper to get user-friendly status label
+const getTrackingStatusLabel = (status: string) => {
+  switch (status) {
+    case "FC":
+      return "Label issued";
+    case "POSTED":
+      return "Posted";
+    case "IN_TRANSIT":
+      return "In transit";
+    case "DELIVERED":
+      return "Delivered";
+    case "NOT_FOUND":
+      return "Not found";
+    case "UNKNOWN":
+    default:
+      return "Unknown";
+  }
+};
+
 export async function DashboardWidgetsServer() {
   // Server-side data fetching
   const orderStats = await api.order.getOrderStats();
@@ -9,7 +28,7 @@ export async function DashboardWidgetsServer() {
 
   // Transform data for the client component
   const chartData = orderStats?.statusBreakdown.map((stat) => ({
-    name: stat.shippingStatus,
+    name: getTrackingStatusLabel(stat.shippingStatus),
     value: stat._count,
   })) ?? [];
 

--- a/src/app/_components/orders/dashboard/DashboardWidgetsServer.tsx
+++ b/src/app/_components/orders/dashboard/DashboardWidgetsServer.tsx
@@ -15,7 +15,6 @@ const getTrackingStatusLabel = (status: string) => {
       return "Delivered";
     case "NOT_FOUND":
       return "Not found";
-    case "UNKNOWN":
     default:
       return "Unknown";
   }

--- a/src/app/_components/orders/management/SearchFilters.tsx
+++ b/src/app/_components/orders/management/SearchFilters.tsx
@@ -45,8 +45,8 @@ export const SearchFilters = ({
       </SelectTrigger>
       <SelectContent>
         <SelectItem value="all"><span>All Statuses</span></SelectItem>
-        <SelectItem value={OrderStatus.POSTED}><span>Posted</span>
-        </SelectItem>
+        <SelectItem value={OrderStatus.FC}><span>Label issued</span></SelectItem>
+        <SelectItem value={OrderStatus.POSTED}><span>Posted</span></SelectItem>
         <SelectItem value={OrderStatus.NOT_FOUND}><span>Not found</span></SelectItem>
         <SelectItem value={OrderStatus.IN_TRANSIT}><span>In transit</span></SelectItem>
         <SelectItem value={OrderStatus.DELIVERED}><span>Delivered</span></SelectItem>

--- a/src/app/_components/orders/table/OrdersTable.tsx
+++ b/src/app/_components/orders/table/OrdersTable.tsx
@@ -93,6 +93,8 @@ export function OrdersTable({
 
   const getTrackingStatusColor = (status: OrderStatus) => {
     switch (status) {
+      case "FC":
+        return "bg-purple-100 text-purple-800";
       case "POSTED":
         return "bg-yellow-100 text-yellow-800";
       case "IN_TRANSIT":

--- a/src/app/_components/orders/table/OrdersTable.tsx
+++ b/src/app/_components/orders/table/OrdersTable.tsx
@@ -107,6 +107,24 @@ export function OrdersTable({
     }
   };
 
+  const getTrackingStatusLabel = (status: OrderStatus) => {
+    switch (status) {
+      case "FC":
+        return "Label issued";
+      case "POSTED":
+        return "Posted";
+      case "IN_TRANSIT":
+        return "In transit";
+      case "DELIVERED":
+        return "Delivered";
+      case "NOT_FOUND":
+        return "Not found";
+      case "UNKNOWN":
+      default:
+        return "Unknown";
+    }
+  };
+
   const getSortIcon = (field: "orderNumber" | "updatedAt") => {
     if (sortBy !== field) return <ArrowUpDown className="ml-2 h-4 w-4" />;
     return (
@@ -186,7 +204,7 @@ export function OrdersTable({
                     variant="secondary"
                     className={getTrackingStatusColor(order.shippingStatus)}
                   >
-                    {order.shippingStatus}
+                    {getTrackingStatusLabel(order.shippingStatus)}
                   </Badge>
                 </TableCell>
                 <TableCell>{order.trackingCode ?? "N/A"}</TableCell>

--- a/src/app/_components/orders/table/OrdersTable.tsx
+++ b/src/app/_components/orders/table/OrdersTable.tsx
@@ -101,7 +101,6 @@ export function OrdersTable({
         return "bg-green-100 text-green-800";
       case "NOT_FOUND":
         return "bg-red-100 text-red-800";
-      case "UNKNOWN":
       default:
         return "bg-gray-100 text-gray-800";
     }
@@ -119,7 +118,6 @@ export function OrdersTable({
         return "Delivered";
       case "NOT_FOUND":
         return "Not found";
-      case "UNKNOWN":
       default:
         return "Unknown";
     }

--- a/src/server/api/routers/tracking.ts
+++ b/src/server/api/routers/tracking.ts
@@ -20,17 +20,28 @@ const updateTrackingSchema = z.object({
 });
 
 // Helper function to determine order status
-const determineOrderStatus = (status: string): OrderStatus => {
-  const normalizedStatus = status.toLowerCase();
-  if (normalizedStatus.includes("entregue")) {
-    return OrderStatus.DELIVERED;
-  } else if (
-    normalizedStatus.includes("trânsito") ||
-    normalizedStatus.includes("transito")
-  ) {
-    return OrderStatus.IN_TRANSIT;
+const determineOrderStatus = (eventCode: string): OrderStatus => {
+  const code = eventCode?.trim().toUpperCase();
+  switch (code) {
+    case "FC":
+      return OrderStatus.FC; // Etiqueta emitida
+    case "PO":
+      return OrderStatus.POSTED; // Postagem
+    case "RO":
+      return OrderStatus.IN_TRANSIT; // Recebido em unidade
+    case "DO":
+      return OrderStatus.IN_TRANSIT; // Despacho
+    case "OEC":
+      return OrderStatus.IN_TRANSIT; // Saiu para entrega
+    case "BDE":
+      return OrderStatus.DELIVERED; // Entregue
+    case "BDI":
+      return OrderStatus.DELIVERED; // Entregue
+    case "BDR":
+      return OrderStatus.DELIVERED; // Entregue
+    default:
+      return OrderStatus.UNKNOWN;
   }
-  return OrderStatus.POSTED;
 };
 
 // Initialize the auth repository (can be reused)
@@ -125,6 +136,7 @@ const processTrackingInfo = async (
   trackingCode: string,
 ) => {
   const tracking = await correiosRepo.getObjectTracking(trackingCode, "U");
+  console.log("[processTrackingInfo] Tracking response:", tracking?.objetos[0]?.eventos);
 
   if (!tracking?.objetos?.[0]?.eventos?.length) {
     return {
@@ -145,7 +157,7 @@ const processTrackingInfo = async (
 
   return {
     success: true,
-    status: determineOrderStatus(latestEvent.descricao),
+    status: determineOrderStatus(latestEvent.codigo),
     data: {
       status: latestEvent.descricao,
       lastUpdate: latestEvent.dtHrCriado,
@@ -368,6 +380,7 @@ export const trackingRouter = createTRPCRouter({
             
             // Group orders by status to reduce database calls
             const orderUpdates: Record<OrderStatus, string[]> = {
+              [OrderStatus.FC]: [],
               [OrderStatus.DELIVERED]: [],
               [OrderStatus.IN_TRANSIT]: [],
               [OrderStatus.POSTED]: [],
@@ -395,7 +408,7 @@ export const trackingRouter = createTRPCRouter({
                 return;
               }
               
-              const status = determineOrderStatus(latestEvent.descricao);
+              const status = determineOrderStatus(latestEvent.codigo);
               orderUpdates[status].push(order.id);
             });
             


### PR DESCRIPTION
- Introduced 'FC' (FICHA_CADASTRAL) status to the OrderStatus enum in the Prisma schema.
- Updated migration script to add the new enum value and adjust foreign key constraints.
- Enhanced DashboardWidgetsServer, OrdersTable, and SearchFilters components to display the new status label.
- Modified tracking logic to recognize and handle the new 'FC' status appropriately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new "Label issued" status for orders, visible in status filters and order tables.
- **Improvements**
  - Order status labels are now more user-friendly and descriptive throughout the dashboard and tables.
  - Order status determination now uses standardized event codes for more accurate tracking updates.
- **Bug Fixes**
  - Improved accuracy of order tracking by mapping shipping statuses based on event codes rather than descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->